### PR TITLE
#6 - Level entries sorted by level

### DIFF
--- a/_includes/skills.html
+++ b/_includes/skills.html
@@ -1,4 +1,5 @@
-{% for entry in site.ladder %}
+{% assign entries = site.ladder | sort: "level" %}
+{% for entry in entries %}
 {% if page.skill == entry.skill %}
   <h2>level {{ entry.level }}</h2>
   <p>{{ entry.content }}</p>


### PR DESCRIPTION
## Problem
On the skills/ pages, the levels were not sorted numerically. The result was the description for levels 8 & 9 ended up under level 14.

![Screenshot 2023-02-17 at 15 14 51](https://user-images.githubusercontent.com/8698839/219679368-abfecc08-bcbe-4f27-9244-4d7f867bb5f7.png)

## Reason
Theoretically, we had the piece of setting that was sorting the descriptions by level. In the `_config.yml` file, we have `sort_by: level` defined.

However, that sorting configuration was introduced in version [4.0 of Jekyll](https://jekyllrb.com/docs/collections/#custom-sorting-of-documents). It happens that GitHub Pages is using [version 3.9](https://pages.github.com/versions/). Because of that, the `sort_by: level` setting is skipped.

## Fix
Add alternative sorting when the collection is accessed, using [Liquid](https://jekyllrb.com/docs/liquid/filters/).

Instead of relying on the `sort_by`, additional sorting is added just before the rendering of the page. Thanks to that, the entries are correctly sorted by the numerical value of `level` attribute.

![Screenshot 2023-02-17 at 15 22 13](https://user-images.githubusercontent.com/8698839/219680604-bd6698ca-a84e-40fe-ae19-f0fe950bc990.png)




